### PR TITLE
PKG-9760: superqt 0.6.7 rebuild

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: af80d5687ec75df6c3e54119ee895e42f79742ed326684c79425414b5c20f1e3
 
 build:
-  number: 0
+  number: 1
   skip: True  # [py<38]
   script: {{ PYTHON }} -m pip install -vv --no-deps --no-build-isolation .
 


### PR DESCRIPTION
For some reason, SuperQt 0.6.7 is not available only on the OSX target for py313.

```
conda_search superqt
Loading channels: done
# Name                       Version           Build  Channel             
superqt                        0.6.7 py310h33ce5c2_0  main                
superqt                        0.6.7 py310h33ce5c2_0  pkgs/main           
superqt                        0.6.7 py311hb6e6a13_0  main                
superqt                        0.6.7 py311hb6e6a13_0  pkgs/main           
superqt                        0.6.7 py312h989b03a_0  main                
superqt                        0.6.7 py312h989b03a_0  pkgs/main           
superqt                        0.6.7  py38h33ce5c2_0  main                
superqt                        0.6.7  py38h33ce5c2_0  pkgs/main           
superqt                        0.6.7  py39h33ce5c2_0  main                
superqt                        0.6.7  py39h33ce5c2_0  pkgs/main     
```
